### PR TITLE
Clion module std workaround

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
         "dockerfile": "Dockerfile",
         "args": {
             "CLANG_VERSION": "20",
-            "CMAKE_VERSION": "4.0.1"
+            "CMAKE_VERSION": "4.0.2"
         }
     },
     "capAdd": [

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,7 @@ cpprog_init()
 
 project(CppProgLaboX VERSION 0.0.1 LANGUAGES C CXX)
 
-add_subdirectory(src)
+cpprog_configure_project()
 
-include(CTest)
-enable_testing()
+add_subdirectory(src)
 add_subdirectory(tests)

--- a/cmake/cpprog.cmake
+++ b/cmake/cpprog.cmake
@@ -7,7 +7,24 @@ macro(cpprog_init)
     _cpprog_enable_lto()
     _cpprog_find_clang_tidy()
     _cpprog_generate_debuginit()
+    _cpprog_clion_clangd_workaround()
 endmacro()
+
+function(_cpprog_clion_clangd_workaround)
+    if($ENV{CLION_IDE})
+        message(STATUS "[cpprog] Detected clion, applying workaround for module std.")
+        set(cpprog_LIBCXX_DIR "/usr/lib/llvm-20/share/libc++/v1")
+        if(NOT EXISTS "${cpprog_LIBCXX_DIR}")
+            message(FATAL_ERROR "[cpprog] libc++ not found at ${cpprog_LIBCXX_DIR}")
+        endif()
+        add_library(clion_workaround_std_target STATIC EXCLUDE_FROM_ALL)
+        target_sources(clion_workaround_std_target
+            PRIVATE FILE_SET CXX_MODULES
+            BASE_DIRS "${cpprog_LIBCXX_DIR}"
+            FILES "${cpprog_LIBCXX_DIR}/std.cppm" "${cpprog_LIBCXX_DIR}/std.compat.cppm"
+        )
+    endif()
+endfunction()
 
 macro(_cpprog_generate_compile_commands)
     set(CMAKE_EXPORT_COMPILE_COMMANDS ON)

--- a/cmake/cpprog.cmake
+++ b/cmake/cpprog.cmake
@@ -17,7 +17,7 @@ endmacro()
 macro(_cpprog_generate_compile_commands)
     set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-    file(RELATIVE_PATH cpprog_RELATIVE_BINARY_DIR "${CMAKE_SOURCE_DIR}/build" "${CMAKE_CURRENT_BINARY_DIR}")
+    cmake_path(RELATIVE_PATH CMAKE_CURRENT_BINARY_DIR BASE_DIRECTORY "${CMAKE_SOURCE_DIR}/build" OUTPUT_VARIABLE cpprog_RELATIVE_BINARY_DIR)
 
     execute_process(
         COMMAND "${CMAKE_COMMAND}" -E create_symlink

--- a/cmake/cpprog.cmake
+++ b/cmake/cpprog.cmake
@@ -116,7 +116,7 @@ function(cpprog_generate_version_info)
     )
 
     add_dependencies("${arg_TARGET}" "${cpprog_VERSION_TARGET}")
-    target_sources("${arg_TARGET}" PUBLIC FILE_SET CXX_MODULES FILES "${cpprog_OUTPUT_FILE}")
+    target_sources("${arg_TARGET}" PUBLIC FILE_SET CXX_MODULES BASE_DIRS "${CMAKE_CURRENT_BINARY_DIR}" FILES "${cpprog_OUTPUT_FILE}")
 endfunction()
 
 function(cpprog_add_executable)
@@ -188,8 +188,8 @@ function(_cpprog_configure_target target_name modules sources headers dependenci
     endif()
 
     target_sources("${target_name}"
-        PUBLIC FILE_SET HEADERS BASE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}" FILES ${headers}
-        PUBLIC FILE_SET CXX_MODULES BASE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}" "${CMAKE_CURRENT_BINARY_DIR}" FILES ${modules}
+        PUBLIC FILE_SET HEADERS FILES ${headers}
+        PUBLIC FILE_SET CXX_MODULES FILES ${modules}
         PRIVATE ${sources}
     )
 

--- a/src/cpprog/cpprog_utils.cpp
+++ b/src/cpprog/cpprog_utils.cpp
@@ -4,7 +4,7 @@ import std;
 
 namespace cpprog {
 
-export struct ExpectError : std::runtime_error
+export struct ExpectError final : std::runtime_error
 {
     using std::runtime_error::runtime_error;
 };
@@ -28,7 +28,7 @@ export constexpr void expect(
     }
 }
 
-export struct NarrowingError : std::exception
+export struct NarrowingError final : std::exception
 {
     [[nodiscard]] char const* what() const noexcept override { return "NarrowingError"; }
 };

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,9 +1,5 @@
-find_package(Catch2 CONFIG REQUIRED)
-include(Catch)
-
 cpprog_add_test(
     TARGET test_cpprog
     CXX_SOURCES
     "cpprog.test.cpp"
 )
-


### PR DESCRIPTION
Clion still uses an old version of clangd. There are two issues.

1. Clion clangd is not compatible with `import std`.  As a workaround, a dummy target is added such that the std module is discovered.

   ```cmake
   set(cpprog_LIBCXX_DIR "/usr/lib/llvm-20/share/libc++/v1")
   add_library(clion_workaround_std_target STATIC EXCLUDE_FROM_ALL)
   target_sources(clion_workaround_std_target
     PRIVATE FILE_SET CXX_MODULES
       BASE_DIRS "${cpprog_LIBCXX_DIR}"
       FILES "${cpprog_LIBCXX_DIR}/std.cppm" "${cpprog_LIBCXX_DIR}/std.compat.cppm"
   )
   ```

2. Clion clangd does not discover modules that are generated at build time. This is a problem for the version module fragment of the cpprog module. At the time of writing there is no fix or workaround. The only option is to ignore the errors.